### PR TITLE
Feature/healthcheck endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
 ### Unreleased
+- Add healthcheck endpoint for service
+
+### 0.1.0 2017-03-29
 - Poll url healthcheck and aliveness endpoints

--- a/rabbit_monitor.py
+++ b/rabbit_monitor.py
@@ -57,7 +57,7 @@ class RabbitMonitor():
             while True:
                 self.call_healthcheck()
                 self.call_aliveness()
-                sleep(self.WAIT_TIME)
+                sleep(self.settings.wait_time)
         except KeyboardInterrupt:
             self.shutdown()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+bottle==0.12.13
 requests==2.13.0

--- a/tests/test_rabbit_monitor.py
+++ b/tests/test_rabbit_monitor.py
@@ -77,5 +77,17 @@ class TestRabbitHealthcheck(unittest.TestCase):
             self.assertEqual(cm.exception.code, 0)
 
 
+class TestSelfHealthcheck(unittest.TestCase):
+
+    def setUp(self):
+        self.rm = RabbitMonitor()
+
+    def test_healthcheck_endpoint(self):
+        self.rm.healthcheck()
+
+        status = self.rm.healthcheck()
+        self.assertEqual(200, status)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_rabbit_monitor.py
+++ b/tests/test_rabbit_monitor.py
@@ -4,14 +4,14 @@ import unittest
 
 import responses
 
+import rabbit_monitor
 from rabbit_monitor import RabbitMonitor
 import settings
 
 
 class TestRabbitHealthcheck(unittest.TestCase):
 
-    def setUp(self):
-        self.rm = RabbitMonitor()
+    rm = RabbitMonitor()
 
     def test_process_healthcheck(self):
         url = settings.URLS['healthcheck']
@@ -76,17 +76,8 @@ class TestRabbitHealthcheck(unittest.TestCase):
             self.rm.shutdown()
             self.assertEqual(cm.exception.code, 0)
 
-
-class TestSelfHealthcheck(unittest.TestCase):
-
-    def setUp(self):
-        self.rm = RabbitMonitor()
-
-    def test_healthcheck_endpoint(self):
-        self.rm.healthcheck()
-
-        status = self.rm.healthcheck()
-        self.assertEqual(200, status)
+    def test_healthcheck_endpoint_method(self):
+        self.assertEqual('{"status": "ok"}', rabbit_monitor.healthcheck())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implements a simple bottle server that will listen for a request to `hostname:port/healthcheck` and return 200 if the server is running.