### PR TITLE
Adding disk space and memory usage checks

### DIFF
--- a/rabbit_monitor.py
+++ b/rabbit_monitor.py
@@ -50,7 +50,8 @@ nodes_url = settings.rabbit_url + 'nodes'
 urls = {'healthcheck': healthcheck_url,
         'aliveness': aliveness_url,
         'messages': message_url,
-        'nodes': nodes_url}
+        'nodes': nodes_url,
+        }
 
 
 @asyncio.coroutine

--- a/rabbit_monitor.py
+++ b/rabbit_monitor.py
@@ -12,6 +12,9 @@ from structlog import wrap_logger
 
 import settings
 
+BYTES_IN_GB = 1073741824
+BYTES_IN_MB = 1048576
+
 __version__ = "0.0.1"
 
 logging.basicConfig(level=settings.LOGGING_LEVEL,
@@ -38,13 +41,16 @@ settings = Settings(port=os.getenv("PORT", 5000),
 healthcheck_url = settings.rabbit_url + 'healthchecks/node'
 aliveness_url = (settings.rabbit_url +
                  'aliveness-test/{}'.format(settings.rabbit_default_vhost))
+
 message_url = (settings.rabbit_url +
                'overview/')
+
+nodes_url = settings.rabbit_url + 'nodes'
 
 urls = {'healthcheck': healthcheck_url,
         'aliveness': aliveness_url,
         'messages': message_url,
-        }
+        'nodes': nodes_url}
 
 
 @asyncio.coroutine
@@ -107,6 +113,61 @@ def message_count(session, url=None):
 
 
 @asyncio.coroutine
+def nodes_info(session, url=None):
+    logger.info('Getting rabbit disk space')
+    if url is None:
+        resp = yield from fetch(session, urls['nodes'])
+    else:
+        resp = yield from fetch(session, url)
+
+    if resp.status == 200:
+        nodes = yield from resp.json()
+        for node in nodes:
+            name = node['name']
+            free_disk_space = node['disk_free']
+            free_disk_space_limit = node['disk_free_limit']
+            percent_disk = _calculate_percentage(free_disk_space, free_disk_space_limit)
+            memory_used = node['mem_used']
+            memory_used_limit = node['mem_limit']
+            percent_mem = _calculate_percentage(memory_used_limit, memory_used)
+
+            logger.info('Rabbit disk space', status=resp.status, node=name,
+                        free_disk_space=_convert_to_gigabytes(free_disk_space),
+                        free_disk_space_limit=_convert_to_gigabytes(free_disk_space_limit),
+                        percentage_away_from_limit=percent_disk)
+
+            logger.info('Rabbit memory', status=resp.status, node=name,
+                        memory_used=_convert_to_megabytes(memory_used),
+                        memory_used_limit=_convert_to_megabytes(memory_used_limit),
+                        percentage_away_from_limit=percent_mem)
+    else:
+        logger.error('Rabbit disk space unavailable', status=resp.status)
+    return name, free_disk_space, free_disk_space_limit, percent_disk, memory_used, memory_used_limit, percent_mem
+
+
+def _calculate_percentage(value1, value2):
+    percentage = (value1 - value2) / value1
+    percentage = percentage * 100
+    percentage = round(percentage, 2)
+    percentage = str(percentage)
+    return percentage + '%'
+
+
+def _convert_to_gigabytes(mem_in_bytes):
+    gb = mem_in_bytes / BYTES_IN_GB
+    gb = round(gb, 2)
+    gb = str(gb) + "GB"
+    return gb
+
+
+def _convert_to_megabytes(mem_in_bytes):
+    mb = mem_in_bytes / BYTES_IN_MB
+    mb = round(mb, 2)
+    mb = str(mb) + "MB"
+    return mb
+
+
+@asyncio.coroutine
 def monitor_rabbit(app):
     auth = aiohttp.BasicAuth(settings.rabbit_default_pass,
                              settings.rabbit_default_user)
@@ -119,6 +180,7 @@ def monitor_rabbit(app):
                 aliveness(session),
                 healthcheck(session),
                 message_count(session),
+                nodes_info(session),
             ]
             tasks = asyncio.gather(*[task for task in tasks],
                                    return_exceptions=True)

--- a/tests/test_rabbit_monitor.py
+++ b/tests/test_rabbit_monitor.py
@@ -5,7 +5,8 @@ import aiohttp
 from aiohttp import web
 import pytest
 
-from rabbit_monitor import fetch, self_healthcheck, message_count
+
+from rabbit_monitor import fetch, self_healthcheck, message_count, nodes_info
 
 
 @pytest.fixture
@@ -14,6 +15,7 @@ def cli(loop, test_client):
     app.router.add_get('/healthcheck', self_healthcheck)
     app.router.add_get('/rabbit_aliveness_good', rabbit_fetch_good)
     app.router.add_get('/test_message_count', mock_message_count)
+    app.router.add_get('/test_nodes', mock_nodes)
     return loop.run_until_complete(test_client(app))
 
 
@@ -58,6 +60,31 @@ def test_message_counts(cli):
     assert 0.0 == queue_totals.get('messages_details', {}).get('rate')
     assert 1 == queue_totals.get('messages_ready')
     assert 1 == queue_totals.get('messages_unacknowledged')
+
+
+@asyncio.coroutine
+def mock_nodes(request):
+    return web.json_response([{"name": "rabbit@76b7837eff57",
+                               "mem_limit": 838474137,
+                               "disk_free_limit": 50000000,
+                               "mem_used": 77209008,
+                               "disk_free": 58268864512}],
+                             status=200)
+
+
+@asyncio.coroutine
+def test_node_info(cli):
+    port = cli.server.port
+    url = 'http://localhost:{}/test_nodes'.format(port)
+    session = aiohttp.ClientSession()
+    name, free_disk_space, free_disk_space_limit, percent_disk, memory_used, memory_used_limit, percent_mem = yield from nodes_info(session, url)
+    assert "rabbit@76b7837eff57" == name
+    assert 58268864512 == free_disk_space
+    assert 77209008 == memory_used
+    assert 50000000 == free_disk_space_limit
+    assert 838474137 == memory_used_limit
+    assert '99.91%' == percent_disk
+    assert '90.79%' == percent_mem
 
 
 @asyncio.coroutine


### PR DESCRIPTION
**Overview**

Adding a call to the rabbit management api to get node information. Using the JSON data from this call to determine the following stats:

- Free disk space
- Free disk space limit before alarm triggered
- Percentage of disk space remaining before alarm triggered
- Memory in use
- Memory in use limit before alarm trigger
- Percentage of memory usage before alarm triggered

These are then written to a log file for later anaylsis

