### PR TITLE
Update travis with supported python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
+dist: xenial
 python:
+    - "3.7"
     - "3.6"
-    - "3.5"
-    - "3.4"
+sudo: required
 before_install:
     - pip install --upgrade pip
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ### Unreleased
+- Remove python 3.4 and 3.5 from travis builds
+- Add python 3.7 to travis builds
 
 ### 1.4.0 2017-11-21
 - Add Cloudfoundry deployment files


### PR DESCRIPTION
## What? and Why?
Since upgrading everything to 3.6, we no longer need to test 3.4 and 3.5.
Also added 3.7 for when we eventually upgrade to it so we can have confidence that it works

## Checklist
  - [x] CHANGELOG.md updated? (if required)
